### PR TITLE
Update the header to be more compatible with VS2022

### DIFF
--- a/getopt.h
+++ b/getopt.h
@@ -21,6 +21,7 @@ Revisions:
 08/01/2012 - Ludvik Jerabek - Created separate functions for char and wchar_t characters so single dll can do both unicode and ansi
 10/15/2012 - Ludvik Jerabek - Modified to match latest GNU features
 06/19/2015 - Ludvik Jerabek - Fixed maximum option limitation caused by option_a (255) and option_w (65535) structure val variable
+09/10/2023 - Mark Harfouche - Fixed compatibility with VS2022
 
 **DISCLAIMER**
 THIS MATERIAL IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND,
@@ -57,12 +58,8 @@ EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 	// Change behavior for C\C++
 	#ifdef __cplusplus
-		#define _BEGIN_EXTERN_C extern "C" {
-		#define _END_EXTERN_C }
 		#define _GETOPT_THROW throw()
 	#else
-		#define _BEGIN_EXTERN_C
-		#define _END_EXTERN_C
 		#define _GETOPT_THROW
 	#endif
 
@@ -70,7 +67,7 @@ EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 	#define	null_argument		0	/*Argument Null*/
 	#define	no_argument			0	/*Argument Switch Only*/
 	#define required_argument	1	/*Argument Required*/
-	#define optional_argument	2	/*Argument Optional*/	
+	#define optional_argument	2	/*Argument Optional*/
 
 	// Shorter Options
 	#define ARG_NULL	0	/*Argument Null*/
@@ -81,7 +78,9 @@ EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 	#include <string.h>
 	#include <wchar.h>
 
-_BEGIN_EXTERN_C
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 	extern _GETOPT_API int optind;
 	extern _GETOPT_API int opterr;
@@ -111,12 +110,12 @@ _BEGIN_EXTERN_C
 	extern _GETOPT_API wchar_t *optarg_w;
 	extern _GETOPT_API int getopt_w(int argc, wchar_t *const *argv, const wchar_t *optstring) _GETOPT_THROW;
 	extern _GETOPT_API int getopt_long_w(int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW;
-	extern _GETOPT_API int getopt_long_only_w(int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW;	
-	
-_END_EXTERN_C
+	extern _GETOPT_API int getopt_long_only_w(int argc, wchar_t *const *argv, const wchar_t *options, const struct option_w *long_options, int *opt_index) _GETOPT_THROW;
 
-	#undef _BEGIN_EXTERN_C
-	#undef _END_EXTERN_C
+#ifdef __cplusplus
+}
+#endif
+
 	#undef _GETOPT_THROW
 	#undef _GETOPT_API
 


### PR DESCRIPTION
An alternative to
https://github.com/libimobiledevice-win32/getopt/pull/1

I think this alternative is "more simple"